### PR TITLE
Update base_virt_ipi.yml - new url is needed

### DIFF
--- a/tasks/base_virt_ipi.yml
+++ b/tasks/base_virt_ipi.yml
@@ -178,7 +178,7 @@
 
 - name: Downloading CentOS 8 base image
   ansible.builtin.get_url:
-    url: https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20230501.0.x86_64.qcow2
+    url: https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20230308.3.x86_64.qcow2
     dest: /var/lib/libvirt/images/centos8-kvm.qcow2
     mode: 0644
   when: not base_result.stat.exists


### PR DESCRIPTION
https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20230308.3.x86_64.qcow2 

as getting


TASK [ocp4_aio_base_virt : Downloading CentOS 8 base image] ********************
fatal: [hypervisor]: FAILED! => {"changed": false, "dest": "/var/lib/libvirt/images/centos8-kvm.qcow2", "elapsed": 0, "msg": "Request failed", "response": "HTTP Error 404: Not Found", "status_code": 404, "url": "https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20220913.0.x86_64.qcow2"}